### PR TITLE
Added option to only change stream title or game

### DIFF
--- a/Actions/SetTitleGameAction.cs
+++ b/Actions/SetTitleGameAction.cs
@@ -35,7 +35,7 @@ namespace SuchByte.TwitchPlugin.Actions
                         configModel.Game = configModel.Game.Replace("{" + variable.Name + "}", variable.Value.ToString(), StringComparison.OrdinalIgnoreCase);
                     }
                 }
-                TwitchHelper.SetTitleGame(configModel.StreamTitle, configModel.Game);
+                TwitchHelper.SetTitleGame(configModel.UseStreamTitle ? configModel.StreamTitle : null, configModel.UseGame ? configModel.Game : null);
             }
         }
 

--- a/Models/SetTitleGameActionConfigModel.cs
+++ b/Models/SetTitleGameActionConfigModel.cs
@@ -8,7 +8,9 @@ namespace SuchByte.TwitchPlugin.Models
     public class SetTitleGameActionConfigModel : ISerializableConfiguration
     {
         public string StreamTitle { get; set; } = "";
+        public bool UseStreamTitle { get; set; } = true;
         public string Game { get; set; } = "";
+        public bool UseGame { get; set; } = true;
 
         public string Serialize()
         {

--- a/TwitchHelper.cs
+++ b/TwitchHelper.cs
@@ -144,18 +144,17 @@ namespace SuchByte.TwitchPlugin
         {
             try
             {
-                string gameId = "";
-                var games = await _api.Helix.Games.GetGamesAsync(gameNames: new List<string> { game });
-                if (games != null && games.Games != null && games.Games.FirstOrDefault() != null)
+                TwitchLib.Api.Helix.Models.Channels.ModifyChannelInformation.ModifyChannelInformationRequest modifyChannelInformationRequest = new TwitchLib.Api.Helix.Models.Channels.ModifyChannelInformation.ModifyChannelInformationRequest();
+                if (!string.IsNullOrEmpty(game))
                 {
-                    gameId = games.Games.FirstOrDefault().Id;
+                    var games = await _api.Helix.Games.GetGamesAsync(gameNames: new List<string> { game });
+                    if (games != null && games.Games != null && games.Games.FirstOrDefault() != null)
+                    {
+                        modifyChannelInformationRequest.GameId = games.Games.FirstOrDefault().Id;
+                    }
                 }
+                if (string.IsNullOrEmpty(title)) modifyChannelInformationRequest.Title = title;
 
-                TwitchLib.Api.Helix.Models.Channels.ModifyChannelInformation.ModifyChannelInformationRequest modifyChannelInformationRequest = new TwitchLib.Api.Helix.Models.Channels.ModifyChannelInformation.ModifyChannelInformationRequest()
-                {
-                    Title = title,
-                    GameId = gameId
-                };
                 await _api.Helix.Channels.ModifyChannelInformationAsync(userId, modifyChannelInformationRequest);
             }
             catch (Exception ex)
@@ -422,7 +421,14 @@ namespace SuchByte.TwitchPlugin
         {
             if (_api == null) return;
             Task.Run(() => SetTitleGameAsync(title, game));
-            MacroDeckLogger.Info(PluginInstance.Main, $"Set title to {title} and game to {game}");
+            if (!string.IsNullOrEmpty(title) && !string.IsNullOrEmpty(game))
+                MacroDeckLogger.Info(PluginInstance.Main, $"Set title to {title} and game to {game}");
+            else if (!string.IsNullOrEmpty(title))
+                MacroDeckLogger.Info(PluginInstance.Main, $"Set title to {title}");
+            else if (!string.IsNullOrEmpty(game))
+                MacroDeckLogger.Info(PluginInstance.Main, $"Set game to {game}");
+            else
+                MacroDeckLogger.Info(PluginInstance.Main, $"Set nothing");
         }
 
         public static void Marker()

--- a/ViewModels/SetTitleGameActionConfigViewModel.cs
+++ b/ViewModels/SetTitleGameActionConfigViewModel.cs
@@ -21,10 +21,22 @@ namespace SuchByte.TwitchPlugin.ViewModels
             set => Configuration.StreamTitle = value;
         }
 
+        public bool UseStreamTitle
+        {
+            get => Configuration.UseStreamTitle;
+            set => Configuration.UseStreamTitle = value;
+        }
+
         public string Game
         {
             get => Configuration.Game;
             set => Configuration.Game = value;
+        }
+
+        public bool UseGame
+        {
+            get => Configuration.UseGame;
+            set => Configuration.UseGame = value;
         }
 
         public SetTitleGameActionConfigViewModel(PluginAction action)
@@ -49,7 +61,10 @@ namespace SuchByte.TwitchPlugin.ViewModels
 
         public void SetConfig()
         {
-            _action.ConfigurationSummary = "Stream title: " + this.StreamTitle + " | " + "Game: " + this.Game;
+            if (this.UseStreamTitle && this.UseGame) _action.ConfigurationSummary = "Stream title: " + this.StreamTitle + " | " + "Game: " + this.Game;
+            else if (this.UseStreamTitle) _action.ConfigurationSummary = "Stream title: " + this.StreamTitle;
+            else if (this.UseGame) _action.ConfigurationSummary = "Game: " + this.Game;
+            else _action.ConfigurationSummary = "Deactivated";
             _action.Configuration = Configuration.Serialize();
         }
 

--- a/Views/SetTitleGameActionConfigView.Designer.cs
+++ b/Views/SetTitleGameActionConfigView.Designer.cs
@@ -30,25 +30,14 @@ namespace SuchByte.TwitchPlugin.Views
         private void InitializeComponent()
         {
             this.components = new System.ComponentModel.Container();
-            this.lblStreamTitle = new System.Windows.Forms.Label();
             this.streamTitle = new SuchByte.MacroDeck.GUI.CustomControls.RoundedTextBox();
             this.game = new SuchByte.MacroDeck.GUI.CustomControls.RoundedTextBox();
-            this.lblGame = new System.Windows.Forms.Label();
             this.btnAddVariableTitle = new SuchByte.MacroDeck.GUI.CustomControls.ButtonPrimary();
             this.btnAddVariableGame = new SuchByte.MacroDeck.GUI.CustomControls.ButtonPrimary();
             this.variablesContextMenu = new System.Windows.Forms.ContextMenuStrip(this.components);
+            this.cbxStreamTitle = new System.Windows.Forms.CheckBox();
+            this.cbxGame = new System.Windows.Forms.CheckBox();
             this.SuspendLayout();
-            // 
-            // lblStreamTitle
-            // 
-            this.lblStreamTitle.Anchor = System.Windows.Forms.AnchorStyles.None;
-            this.lblStreamTitle.Font = new System.Drawing.Font("Tahoma", 11.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point);
-            this.lblStreamTitle.Location = new System.Drawing.Point(111, 184);
-            this.lblStreamTitle.Name = "lblStreamTitle";
-            this.lblStreamTitle.Size = new System.Drawing.Size(143, 25);
-            this.lblStreamTitle.TabIndex = 0;
-            this.lblStreamTitle.Text = "Stream title";
-            this.lblStreamTitle.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             // 
             // streamTitle
             // 
@@ -93,17 +82,6 @@ namespace SuchByte.TwitchPlugin.Views
             this.game.Size = new System.Drawing.Size(459, 25);
             this.game.TabIndex = 5;
             this.game.TextAlignment = System.Windows.Forms.HorizontalAlignment.Left;
-            // 
-            // lblGame
-            // 
-            this.lblGame.Anchor = System.Windows.Forms.AnchorStyles.None;
-            this.lblGame.Font = new System.Drawing.Font("Tahoma", 11.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point);
-            this.lblGame.Location = new System.Drawing.Point(111, 215);
-            this.lblGame.Name = "lblGame";
-            this.lblGame.Size = new System.Drawing.Size(143, 25);
-            this.lblGame.TabIndex = 4;
-            this.lblGame.Text = "Game";
-            this.lblGame.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             // 
             // btnAddVariableTitle
             // 
@@ -153,16 +131,44 @@ namespace SuchByte.TwitchPlugin.Views
             this.variablesContextMenu.ShowImageMargin = false;
             this.variablesContextMenu.Size = new System.Drawing.Size(156, 26);
             // 
+            // cbxStreamTitle
+            // 
+            this.cbxStreamTitle.Anchor = System.Windows.Forms.AnchorStyles.None;
+            this.cbxStreamTitle.Checked = true;
+            this.cbxStreamTitle.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.cbxStreamTitle.Font = new System.Drawing.Font("Tahoma", 11.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point);
+            this.cbxStreamTitle.Location = new System.Drawing.Point(111, 184);
+            this.cbxStreamTitle.Name = "cbxStreamTitle";
+            this.cbxStreamTitle.Size = new System.Drawing.Size(143, 25);
+            this.cbxStreamTitle.TabIndex = 0;
+            this.cbxStreamTitle.Text = "Stream title";
+            this.cbxStreamTitle.UseVisualStyleBackColor = true;
+            this.cbxStreamTitle.CheckedChanged += new System.EventHandler(this.CbxStreamTitle_CheckedChanged);
+            // 
+            // cbxGame
+            // 
+            this.cbxGame.Anchor = System.Windows.Forms.AnchorStyles.None;
+            this.cbxGame.Checked = true;
+            this.cbxGame.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.cbxGame.Font = new System.Drawing.Font("Tahoma", 11.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point);
+            this.cbxGame.Location = new System.Drawing.Point(111, 215);
+            this.cbxGame.Name = "cbxGame";
+            this.cbxGame.Size = new System.Drawing.Size(143, 25);
+            this.cbxGame.TabIndex = 8;
+            this.cbxGame.Text = "Game";
+            this.cbxGame.UseVisualStyleBackColor = true;
+            this.cbxGame.CheckedChanged += new System.EventHandler(this.CbxGame_CheckedChanged);
+            // 
             // SetTitleGameActionConfigView
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(10F, 23F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.Controls.Add(this.cbxGame);
+            this.Controls.Add(this.cbxStreamTitle);
             this.Controls.Add(this.btnAddVariableGame);
             this.Controls.Add(this.btnAddVariableTitle);
             this.Controls.Add(this.game);
-            this.Controls.Add(this.lblGame);
             this.Controls.Add(this.streamTitle);
-            this.Controls.Add(this.lblStreamTitle);
             this.Name = "SetTitleGameActionConfigView";
             this.Load += new System.EventHandler(this.SetTitleGameActionConfigView_Load);
             this.ResumeLayout(false);
@@ -171,12 +177,12 @@ namespace SuchByte.TwitchPlugin.Views
 
         #endregion
 
-        private System.Windows.Forms.Label lblStreamTitle;
         private MacroDeck.GUI.CustomControls.RoundedTextBox streamTitle;
         private MacroDeck.GUI.CustomControls.RoundedTextBox game;
-        private System.Windows.Forms.Label lblGame;
         private MacroDeck.GUI.CustomControls.ButtonPrimary btnAddVariableTitle;
         private MacroDeck.GUI.CustomControls.ButtonPrimary btnAddVariableGame;
         private System.Windows.Forms.ContextMenuStrip variablesContextMenu;
+        private System.Windows.Forms.CheckBox cbxStreamTitle;
+        private System.Windows.Forms.CheckBox cbxGame;
     }
 }

--- a/Views/SetTitleGameActionConfigView.cs
+++ b/Views/SetTitleGameActionConfigView.cs
@@ -19,29 +19,38 @@ namespace SuchByte.TwitchPlugin.Views
         public SetTitleGameActionConfigView(PluginAction action)
         {
             InitializeComponent();
-            this.lblStreamTitle.Text = PluginLanguageManager.PluginStrings.StreamTitle;
-            this.lblGame.Text = PluginLanguageManager.PluginStrings.Game;
+            this.cbxStreamTitle.Text = PluginLanguageManager.PluginStrings.StreamTitle;
+            this.cbxGame.Text = PluginLanguageManager.PluginStrings.Game;
             this._viewModel = new SetTitleGameActionConfigViewModel(action);
         }
 
         private void SetTitleGameActionConfigView_Load(object sender, EventArgs e)
         {
             this.streamTitle.Text = this._viewModel.StreamTitle;
+            this.cbxStreamTitle.Checked = this._viewModel.UseStreamTitle;
             this.game.Text = this._viewModel.Game;
+            this.cbxGame.Checked = this._viewModel.UseGame;
         }
 
         public override bool OnActionSave()
         {
-            if (string.IsNullOrWhiteSpace(this.streamTitle.Text))
+            if (this.cbxStreamTitle.Checked && string.IsNullOrWhiteSpace(this.streamTitle.Text))
             {
                 return false;
             }
-            if (string.IsNullOrWhiteSpace(this.game.Text))
+            if (this.cbxGame.Checked && string.IsNullOrWhiteSpace(this.game.Text))
             {
                 return false;
             }
+            if (!this.cbxStreamTitle.Checked && !cbxGame.Checked)
+            {
+                return false;
+            }
+
             this._viewModel.StreamTitle = this.streamTitle.Text;
+            this._viewModel.UseStreamTitle = this.cbxStreamTitle.Checked;
             this._viewModel.Game = this.game.Text;
+            this._viewModel.UseGame = this.cbxGame.Checked;
             return this._viewModel.SaveConfig();
         }
 
@@ -90,6 +99,16 @@ namespace SuchByte.TwitchPlugin.Views
             var selectionIndex = this.game.SelectionStart;
             this.game.Text = this.game.Text.Insert(selectionIndex, "{" + item.Text + "}");
             this.game.SelectionStart = selectionIndex + ("{" + item.Text + "}").Length;
+        }
+
+        private void CbxStreamTitle_CheckedChanged(object sender, EventArgs e)
+        {
+            streamTitle.Enabled = cbxStreamTitle.Checked;
+        }
+
+        private void CbxGame_CheckedChanged(object sender, EventArgs e)
+        {
+            game.Enabled = cbxGame.Checked;
         }
     }
 }


### PR DESCRIPTION
Switches the labels to set the stream title and game to checkboxes, so that the user can choose which to update and which not.
Not in every case it's needed to set both.