### PR TITLE
Bump dependency versions

### DIFF
--- a/Macro Deck Twitch Plugin.csproj
+++ b/Macro Deck Twitch Plugin.csproj
@@ -30,8 +30,8 @@
 
   <ItemGroup>
     <PackageReference Include="System.Drawing.Common" Version="5.0.2" />
-    <PackageReference Include="TwitchLib" Version="3.4.1" />
-    <PackageReference Include="TwitchLib.Api.Helix" Version="3.6.1" />
+    <PackageReference Include="TwitchLib" Version="3.5.3" />
+    <PackageReference Include="TwitchLib.Api.Helix" Version="3.9.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- Bump TwitchLib to 3.5.3
- Bump TwitchLib.Api.Helix to 3.9.0